### PR TITLE
fix "semaphore" typo

### DIFF
--- a/notes/计算机操作系统.md
+++ b/notes/计算机操作系统.md
@@ -259,7 +259,7 @@ shortest remaining time next（SRTN）。
 
 ### 3. 信号量
 
-**信号量（Samaphore）** 是一个整型变量，可以对其执行 down 和 up 操作，也就是常见的 P 和 V 操作。
+**信号量（Semaphore）** 是一个整型变量，可以对其执行 down 和 up 操作，也就是常见的 P 和 V 操作。
 
 - **down** : 如果信号量大于 0 ，执行 -1 操作；如果信号量等于 0，将进程睡眠，等待信号量大于 0；
 - **up**：对信号量执行 +1 操作，并且唤醒睡眠的进程，让进程完成 down 操作。
@@ -269,8 +269,8 @@ down 和 up 操作需要被设计成原语，不可分割，通常的做法是�
 如果信号量的取值只能为 0 或者 1，那么就成为了**互斥量（Mutex）**，0 表示临界区已经加锁，1 表示临界区解锁。
 
 ```c
-typedef int samaphore;
-samaphore mutex = 1;
+typedef int semaphore;
+semaphore mutex = 1;
 void P1() {
     down(mutex);
     // 临界区
@@ -292,10 +292,10 @@ void P2() {
 
 ```c
 #define N 100
-typedef int samaphore;
-samaphore mutex = 1;
-samaphore empty = N;
-samaphore full = 0;
+typedef int semaphore;
+semaphore mutex = 1;
+semaphore empty = N;
+semaphore full = 0;
 
 void producer() {
     while(TRUE){


### PR DESCRIPTION
后面的 semaphore 倒是没错