### PR TITLE
JDK1.7、8 已经修改为双向链表

### DIFF
--- a/notes/Java 容器.md
+++ b/notes/Java 容器.md
@@ -212,7 +212,7 @@ private void writeObject(java.io.ObjectOutputStream s)
 
 ### 4. 和 LinkedList 的区别
 
-- ArrayList 基于动态数组实现，LinkedList 基于双向循环链表实现；
+- ArrayList 基于动态数组实现，LinkedList 基于双向链表实现；
 - ArrayList 支持随机访问，LinkedList 不支持；
 - LinkedList 在任意位置添加删除元素更快。
 


### PR DESCRIPTION
![](https://ws1.sinaimg.cn/large/006tKfTcly1fqzaf6egnzj30x60f4q4q.jpg)

![](https://ws2.sinaimg.cn/large/006tKfTcly1fqzgfl59kqj30wu0cgmyj.jpg)

根据1.7、8源码，新增的时候 `next` 指向的是 null。